### PR TITLE
feat(snyk-docker-scan): add policy-path input

### DIFF
--- a/snyk-docker-scan/action.yml
+++ b/snyk-docker-scan/action.yml
@@ -23,6 +23,10 @@ inputs:
   snyk-token:
     description: "Snyk API token. Pass secrets.SNYK_TOKEN. Optional if the job already sets env SNYK_TOKEN."
     required: false
+  policy-path:
+    description: "Path to a .snyk policy file with ignore rules. snyk container test does not auto-load .snyk; pass it explicitly here."
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -35,6 +39,7 @@ runs:
       shell: bash
       env:
         SNYK_TOKEN_FROM_INPUT: ${{ inputs.snyk-token }}
+        POLICY_PATH: ${{ inputs.policy-path }}
       run: |
         SNYK_TOKEN="${SNYK_TOKEN_FROM_INPUT:-$SNYK_TOKEN}"
         if [ -z "$SNYK_TOKEN" ]; then
@@ -43,11 +48,20 @@ runs:
         fi
         snyk auth "$SNYK_TOKEN"
         snyk config set disableSuggestions=true
+        EXTRA_ARGS=()
+        if [ -n "$POLICY_PATH" ]; then
+          if [ ! -f "$POLICY_PATH" ]; then
+            echo "::error::policy-path '$POLICY_PATH' does not exist."
+            exit 1
+          fi
+          EXTRA_ARGS+=("--policy-path=$POLICY_PATH")
+        fi
         snyk_container_test() {
           snyk container test \
             --severity-threshold=${{ inputs.severity-threshold }} \
             --file=${{ inputs.dockerfile }} \
             --fail-on=upgradable \
+            "${EXTRA_ARGS[@]}" \
             "${{ inputs.image }}"
         }
         if [ -n "${{ vars.ALLOW_SNYK_VULNS }}" ]; then


### PR DESCRIPTION
## Summary
- Adds an optional `policy-path` input to `snyk-docker-scan` that is passed to `snyk container test` via `--policy-path`.
- Unlike `snyk test` (OSS), `snyk container test` does **not** auto-load `.snyk` from the working directory, so an explicit flag is required for ignore rules to take effect on container scans.
- The input is optional and defaults to empty — existing callers are unaffected.
- If a path is supplied but the file does not exist, the action fails fast with a clear error.

## Why
The Keycloak repo (and other repos using this action) hit base-image RHEL CVEs that have no upstream fix yet (UBI mirror lag). They need a `.snyk` policy with timed ignores to gate the scan, but the current action ignores the file. This unblocks that pattern.

## Test plan
- [ ] Existing callers continue to work without changes (no `policy-path` passed → no `--policy-path` flag → identical command).
- [ ] In `mindsdb/keycloak` workflows: pass `policy-path: .snyk` and confirm `snyk container test` honors the ignore rules in that file.
- [ ] Pass a non-existent path and confirm the action fails fast with a readable error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)